### PR TITLE
ticket 29: Create V4 endpoint for creating case with String type for RequestBody

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,14 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<version>2.17.2</version>
+		</dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/mytech/casemanagement/config/JacksonConfig.java
+++ b/src/main/java/com/mytech/casemanagement/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package com.mytech.casemanagement.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/mytech/casemanagement/controller/CaseController.java
+++ b/src/main/java/com/mytech/casemanagement/controller/CaseController.java
@@ -1,9 +1,6 @@
 package com.mytech.casemanagement.controller;
 
-import com.mytech.casemanagement.entity.Case;
-import com.mytech.casemanagement.entity.CaseNew;
-import com.mytech.casemanagement.entity.CaseStatusEnum;
-import com.mytech.casemanagement.entity.CaseTypeEnum;
+import com.mytech.casemanagement.entity.*;
 import com.mytech.casemanagement.service.CaseActionHandlerService;
 import com.mytech.casemanagement.service.CaseService;
 import com.mytech.casemanagement.service.CaseServiceNew;
@@ -70,7 +67,7 @@ public class CaseController {
             returnCase.setModifiedDate(caseNewEntity.getModifiedDate().atOffset(offset));
             returnCase.setPendingReviewDate(caseNewEntity.getPendingReviewDate().atOffset(offset));
             returnCase.setNote(caseNewEntity.getNote());
-            CaseStatusEnum caseStatus = caseNewEntity.getCaseStatusEnum();
+            CaseStatusEnum caseStatus = caseNewEntity.getCaseStatus();
             switch (caseStatus) {
                 case PendingDocument:
                     returnCase.setCaseStatus(io.swagger.client.model.CaseNew.CaseStatusEnum.PENDINGDOCUMENT);
@@ -81,7 +78,7 @@ public class CaseController {
                 default:
                     throw new IllegalArgumentException("Unknown CaseStatusEnum value: " + caseStatus);
             }
-            CaseTypeEnum caseType = caseNewEntity.getCaseTypeEnum();
+            CaseTypeEnum caseType = caseNewEntity.getCaseType();
             switch (caseType) {
                 case Fraud:
                     returnCase.setCaseType(io.swagger.client.model.CaseNew.CaseTypeEnum.FRAUD);
@@ -139,6 +136,25 @@ public class CaseController {
 
     private ResponseEntity<?> invokeActionHandler(String methodType, String workflow, String action, CaseNew caseNew) {
         return caseActionHandlerService.invokeActionHandler(methodType, workflow, action, caseNew);
+    }
+
+    /*
+     * This is the V4 version, covered by ticket29
+     * in this version, will use String type to receive request body, this way is more generic for ohter actions in future
+     * */
+    @PostMapping("/v4/{workflow}/action/{action}")
+    public ResponseEntity<?> createCaseNew2(
+            @PathVariable("workflow") String workflow,
+            @PathVariable("action") String action,
+            @RequestBody String requestStr){
+        System.out.println("workflow:"+workflow);
+        return invokeActionHandler4(HttpMethod.POST.toString(), workflow,action,requestStr);
+
+    }
+
+    private ResponseEntity<?> invokeActionHandler4(String methodType, String workflow, String action, String requestStr) {
+
+        return caseActionHandlerService.invokeActionHandlerStrRequest(methodType, workflow, action, requestStr);
     }
 
     @PatchMapping

--- a/src/main/java/com/mytech/casemanagement/entity/CaseNew.java
+++ b/src/main/java/com/mytech/casemanagement/entity/CaseNew.java
@@ -18,11 +18,11 @@ public class CaseNew {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "case_status", nullable = false)
-    private CaseStatusEnum caseStatusEnum;
+    private CaseStatusEnum caseStatus;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "case_type", nullable = false)
-    private CaseTypeEnum caseTypeEnum;
+    private CaseTypeEnum caseType;
 
     @Column(name = "created_by", nullable = false)
     private String createdBy;

--- a/src/main/java/com/mytech/casemanagement/entity/RequestObject.java
+++ b/src/main/java/com/mytech/casemanagement/entity/RequestObject.java
@@ -1,0 +1,41 @@
+package com.mytech.casemanagement.entity;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/*@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "action")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = CaseNew.class, name = "create")
+})*/
+public class RequestObject {
+    // No additional fields needed, just use polymorphic serialization
+    private String action;
+    private JsonNode payload;
+
+    // Getter and Setter for action
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    // Getter and Setter for payload
+    public JsonNode getPayload() {
+        return payload;
+    }
+
+    public void setPayload(JsonNode payload) {
+        this.payload = payload;
+    }
+
+    @Override
+    public String toString() {
+        return "RequestObject{" +
+                "action='" + action + '\'' +
+                ", payload='" + payload + '\'' +
+                '}';
+    }
+}
+

--- a/src/main/java/com/mytech/casemanagement/service/CaseServiceNew.java
+++ b/src/main/java/com/mytech/casemanagement/service/CaseServiceNew.java
@@ -74,13 +74,13 @@ public class CaseServiceNew {
             io.swagger.client.model.CaseNew.CaseTypeEnum caseType = caseInMessage.getCaseType();
             switch (caseType){
                 case LOD:
-                    caseNewEntity.setCaseTypeEnum(CaseTypeEnum.LOD);
+                    caseNewEntity.setCaseType(CaseTypeEnum.LOD);
                     break;
                 case FRAUD:
-                    caseNewEntity.setCaseTypeEnum(CaseTypeEnum.Fraud);
+                    caseNewEntity.setCaseType(CaseTypeEnum.Fraud);
                     break;
                 case NETNEW:
-                    caseNewEntity.setCaseTypeEnum(CaseTypeEnum.NetNew);
+                    caseNewEntity.setCaseType(CaseTypeEnum.NetNew);
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown CaseType when converting from Kafka message to entity: "+caseType.toString());
@@ -89,10 +89,10 @@ public class CaseServiceNew {
             io.swagger.client.model.CaseNew.CaseStatusEnum caseStatus = caseInMessage.getCaseStatus();
             switch (caseStatus){
                 case PENDINGDOCUMENT:
-                    caseNewEntity.setCaseStatusEnum(CaseStatusEnum.PendingDocument);
+                    caseNewEntity.setCaseStatus(CaseStatusEnum.PendingDocument);
                     break;
                 case PENDINGREVIEW:
-                    caseNewEntity.setCaseStatusEnum(CaseStatusEnum.PendingReview);
+                    caseNewEntity.setCaseStatus(CaseStatusEnum.PendingReview);
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown CaseStatus when converting from Kafka message to entity: "+caseStatus.toString());

--- a/src/test/java/com/mytech/casemanagement/otherTest/ObjectMapperTests.java
+++ b/src/test/java/com/mytech/casemanagement/otherTest/ObjectMapperTests.java
@@ -1,0 +1,50 @@
+package com.mytech.casemanagement.otherTest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mytech.casemanagement.config.JacksonConfig;
+import com.mytech.casemanagement.entity.CaseNew;
+import com.mytech.casemanagement.entity.RequestObject;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.Request;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@ExtendWith(SpringExtension.class)
+@SpringJUnitConfig(JacksonConfig.class)
+public class ObjectMapperTests {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    public void shouldMapJsonToRequestObject() throws JsonProcessingException {
+        String jsonString="{\n" +
+                "    \"action\": \"create\",\n" +
+                "    \"payload\": {\n" +
+                "        \"caseId\": 102,\n" +
+                "        \"caseStatus\": \"PendingDocument\",\n" +
+                "        \"caseType\": \"NetNew\",\n" +
+                "        \"createdBy\": \"Tony Stark\",\n" +
+                "        \"createDate\": \"2024-09-07T18:59:35\",\n" +
+                "        \"modifiedDate\": \"2024-09-08T18:59:35\",\n" +
+                "        \"pendingReviewDate\": \"2024-09-09T18:59:35\",\n" +
+                "        \"note\": \"using RequestObject mapping.\"\n" +
+                "    }\n" +
+                "}";
+//        ObjectMapper objectMapper = new ObjectMapper();
+        RequestObject requestObject = objectMapper.readValue(jsonString, RequestObject.class);
+        System.out.println("requestObject:"+requestObject.toString());
+        JsonNode payload = requestObject.getPayload();
+        System.out.println("payload:"+payload);
+        // Convert JsonNode to CaseNew object
+//        objectMapper
+        CaseNew caseNew = objectMapper.treeToValue(payload, CaseNew.class);
+        System.out.println("caseNew:"+caseNew);
+    }
+
+}


### PR DESCRIPTION
This is a workable version.CaseNew field name is modified to make it easier to work together with payload.RequestObject class is created. jsr310 dependency and config is added to handle java8 LocalDataTime type by ObjectMapper. CaseNew object could be extracted successfully.