### PR TITLE
ticket 33: Added try-catch bolck for invokeActionHandler4() method.

### DIFF
--- a/src/main/java/com/mytech/casemanagement/controller/CaseController.java
+++ b/src/main/java/com/mytech/casemanagement/controller/CaseController.java
@@ -1,5 +1,6 @@
 package com.mytech.casemanagement.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.mytech.casemanagement.entity.*;
 import com.mytech.casemanagement.service.CaseActionHandlerService;
 import com.mytech.casemanagement.service.CaseService;
@@ -154,7 +155,19 @@ public class CaseController {
 
     private ResponseEntity<?> invokeActionHandler4(String methodType, String workflow, String action, String requestStr) {
         // todo: should try-catch all known exceptions and handle them.
-        return caseActionHandlerService.invokeActionHandlerStrRequest(methodType, workflow, action, requestStr);
+        //todo: should log all the exceptions.
+        ResponseEntity<?> responseEntity = null;
+        try {
+            responseEntity = caseActionHandlerService.invokeActionHandlerStrRequest(methodType, workflow, action, requestStr);
+        } catch (IllegalArgumentException e) {
+//            throw new RuntimeException(e);
+            System.out.println("catch exception in Controller: "+ e.getMessage());
+        }catch (RuntimeException e){
+            System.out.println("catch exception in Controller: "+ e.getMessage());
+        }catch (Exception e) {
+            System.out.println("catch exception in Controller: "+ e.getMessage());
+        }
+        return responseEntity;
     }
 
     @PatchMapping

--- a/src/main/java/com/mytech/casemanagement/service/CaseActionHandlerService.java
+++ b/src/main/java/com/mytech/casemanagement/service/CaseActionHandlerService.java
@@ -7,6 +7,8 @@ import com.mytech.casemanagement.entity.RequestObject;
 import com.mytech.casemanagement.handler.CaseActionHandler;
 import com.mytech.casemanagement.handler.CreateCaseActionHandler;
 import com.mytech.casemanagement.handler.DefaultCaseActionHandler;
+import org.apache.logging.log4j.util.Strings;
+import org.hibernate.boot.model.naming.IllegalIdentifierException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -54,10 +56,11 @@ public class CaseActionHandlerService {
                         System.out.println("caseFromPayload:" + caseFromPayload);
                         return caseActionHandler.doAction();
                     } catch (JsonProcessingException e) {
+                        //lambda can not throw checked exceptions, and for now the exception system is not yet created, so temperately use RuntimeException to wrapper it.
                         throw new RuntimeException("Error parsing payload to CaseNew object", e);
                     }
                 })
-                .orElseThrow(() -> new RuntimeException("requestObject is null or empty or format is not correct;"));
+                .orElseThrow(() -> new IllegalArgumentException("requestObject is null or empty or format is not correct;"));
         return responseEntity;
     }
 

--- a/src/test/java/com/mytech/casemanagement/controller/CaseControllerTests.java
+++ b/src/test/java/com/mytech/casemanagement/controller/CaseControllerTests.java
@@ -1,0 +1,78 @@
+package com.mytech.casemanagement.controller;
+
+import com.mytech.casemanagement.entity.CaseNew;
+import com.mytech.casemanagement.service.CaseActionHandlerService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CaseControllerTests {
+
+    @InjectMocks
+    private CaseController caseController;
+
+    @Mock
+    private CaseActionHandlerService caseActionHandlerService;
+
+    private String requestStr="{\n" +
+            "    \"action\":\"create\",\n" +
+            "    \"payload\": {\n" +
+            "        \"caseIds\": 101,\n" +
+            "        \"caseStatus\": \"PendingDocument\",\n" +
+            "        \"caseType\": \"Fraud\",\n" +
+            "        \"createdBy\": \"John Stark\",\n" +
+            "        \"createDate\": \"2024-08-07T18:59:35\",\n" +
+            "        \"modifiedDate\": \"2024-08-08T18:59:35\",\n" +
+            "        \"pendingReviewDate\": \"2024-08-09T18:59:35\",\n" +
+            "        \"note\": \"using RequestObject mapping.\"\n" +
+            "    }\n" +
+            "}";
+
+    @Test
+    public void happyPathShouldReturnResponseEntity(){
+/*        String requestStr="{\n" +
+                "    \"action\":\"create\",\n" +
+                "    \"payload\": {\n" +
+                "        \"caseIds\": 101,\n" +
+                "        \"caseStatus\": \"PendingDocument\",\n" +
+                "        \"caseType\": \"Fraud\",\n" +
+                "        \"createdBy\": \"John Stark\",\n" +
+                "        \"createDate\": \"2024-08-07T18:59:35\",\n" +
+                "        \"modifiedDate\": \"2024-08-08T18:59:35\",\n" +
+                "        \"pendingReviewDate\": \"2024-08-09T18:59:35\",\n" +
+                "        \"note\": \"using RequestObject mapping.\"\n" +
+                "    }\n" +
+                "}";*/
+        ResponseEntity<?> mockSuccessfulResponseEntity=ResponseEntity.ok().body("Successful Response");
+        ResponseEntity<String> mockResponse = ResponseEntity.ok("Success");
+        when(caseActionHandlerService.invokeActionHandlerStrRequest(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn((ResponseEntity)mockSuccessfulResponseEntity);
+        ResponseEntity<?> response = caseController.createCaseNew2("dar", "create", requestStr);
+        Assertions.assertTrue(response.getStatusCode().value() == 200);
+        String body = (String)response.getBody();
+        System.out.println("body: "+body);
+        Assertions.assertTrue(body.contains("Successful Response"));
+
+/*        ResponseEntity<String> mockResponse = ResponseEntity.ok("Success");
+        when(caseActionHandlerService.invokeActionHandlerStrRequest(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn((ResponseEntity<?>) mockResponse);*/
+    }
+
+    @Test
+    public void shouldThrowIllegalArgumentException(){
+        when(caseActionHandlerService.invokeActionHandlerStrRequest(anyString(),anyString(),anyString(),anyString()))
+                .thenThrow(new IllegalArgumentException("Illegal Argument"));
+        ResponseEntity<?> response = caseController.createCaseNew2("dar", "create", requestStr);
+        Assertions.assertNull(response);
+    }
+}


### PR DESCRIPTION
According to chatGPT, the best practice is to let service throw customized exception. so this ticket ends here.