### PR TITLE
ticket 60: Introduce ErrorResponse and Use it for Handling Retrieve Case Exceptions

### DIFF
--- a/src/main/java/com/mytech/casemanagement/controller/CaseController.java
+++ b/src/main/java/com/mytech/casemanagement/controller/CaseController.java
@@ -1,6 +1,8 @@
 package com.mytech.casemanagement.controller;
 
 import com.mytech.casemanagement.entity.*;
+import com.mytech.casemanagement.exception.CaseResourceNotFoundException;
+import com.mytech.casemanagement.exception.InvalidCaseIdException;
 import com.mytech.casemanagement.service.CaseActionHandlerService;
 import com.mytech.casemanagement.service.CaseServiceNew;
 import com.mytech.casemanagement.service.CaseValidationService;
@@ -39,7 +41,7 @@ public class CaseController {
     public ResponseEntity<?> getCaseByCaseIdNew2(@PathVariable int caseId) {
         //1. handle invalid caseId input
         if(caseId<=0){
-            return new ResponseEntity<>("Invalid caseId: must be a positive integer.Current caseId:"+caseId,HttpStatus.BAD_REQUEST);
+            throw new InvalidCaseIdException("Invalid caseId: must be a positive integer.Current caseId:"+caseId);
         }
         return caseServiceNew.getCaseByCaseId(caseId)
                 .<ResponseEntity<?>> map(caseNew -> {
@@ -48,8 +50,9 @@ public class CaseController {
                     retrieveCaseEmptyRs.setCase(convertedSwaggerCaseNew);
                     return ResponseEntity.status(HttpStatus.OK).body(retrieveCaseEmptyRs);
                 })
-                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
-                        .body("Case not found for ID: " + caseId));
+                .orElseThrow(()->new CaseResourceNotFoundException(String.format("Case not found for ID: %d,workflow: %s.",caseId,"mockedWorkflow")));
+/*                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body("Case not found for ID: " + caseId));*/
 
     }
 

--- a/src/main/java/com/mytech/casemanagement/entity/ErrorResponse.java
+++ b/src/main/java/com/mytech/casemanagement/entity/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.mytech.casemanagement.entity;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class ErrorResponse {
+    private String  errorCode;
+    private String message;
+    private int status;
+    private LocalDate timestamp;
+}
+

--- a/src/main/java/com/mytech/casemanagement/exception/InvalidCaseIdException.java
+++ b/src/main/java/com/mytech/casemanagement/exception/InvalidCaseIdException.java
@@ -1,0 +1,7 @@
+package com.mytech.casemanagement.exception;
+
+public class InvalidCaseIdException extends ManageCaseException{
+    public InvalidCaseIdException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/mytech/casemanagement/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/mytech/casemanagement/exception/handler/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    public static final String invalidCaseIdExceptionErrorCode = "INVALID_CAE_ID";
+    public static final String invalidCaseIdExceptionErrorCode = "INVALID_CASE_ID";
     public static final String caseResourceNotFoundExceptionErrorCode = "CASE_RESOURCE_NOT_FOUND";
     public static final int httpBadRequestStatus = 400;
     public GlobalExceptionHandler() {
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
         String message = String.format("Invalid value type of '%s' for parameter '%s'. Expected type: %s.",
                 e.getValue(), e.getName(), e.getRequiredType().getSimpleName());
         ErrorResponse errorResponse = new ErrorResponse();
-        errorResponse.setErrorCode(caseResourceNotFoundExceptionErrorCode);
+        errorResponse.setErrorCode(invalidCaseIdExceptionErrorCode);
         errorResponse.setStatus(httpBadRequestStatus);
         errorResponse.setMessage(message);
         errorResponse.setTimestamp(LocalDate.now());

--- a/src/main/java/com/mytech/casemanagement/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/mytech/casemanagement/exception/handler/GlobalExceptionHandler.java
@@ -1,17 +1,20 @@
 package com.mytech.casemanagement.exception.handler;
 
-import com.mytech.casemanagement.exception.CaseNewNotProvidedException;
-import com.mytech.casemanagement.exception.CaseNullException;
-import com.mytech.casemanagement.exception.CaseParsingException;
-import com.mytech.casemanagement.exception.CaseResourceNotFoundException;
+import com.mytech.casemanagement.entity.ErrorResponse;
+import com.mytech.casemanagement.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import java.time.LocalDate;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    public static final String invalidCaseIdExceptionErrorCode = "INVALID_CAE_ID";
+    public static final String caseResourceNotFoundExceptionErrorCode = "CASE_RESOURCE_NOT_FOUND";
+    public static final int httpBadRequestStatus = 400;
     public GlobalExceptionHandler() {
         System.out.println("GlobalExceptionHandler initialized");
     }
@@ -22,19 +25,29 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(CaseResourceNotFoundException.class)
-    public ResponseEntity<String> handleCaseResourceNotFoundException(CaseResourceNotFoundException e){
-        return ResponseEntity.badRequest().body(e.getMessage());    //return http status 400
+    public ResponseEntity<ErrorResponse> handleCaseResourceNotFoundException(CaseResourceNotFoundException e){
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setErrorCode(caseResourceNotFoundExceptionErrorCode);
+        errorResponse.setStatus(httpBadRequestStatus);
+        errorResponse.setMessage(e.getMessage());
+        errorResponse.setTimestamp(LocalDate.now());
+        return ResponseEntity.badRequest().body(errorResponse);    //return http status 400
     }
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e){
         return ResponseEntity.badRequest().body(e.getMessage());    //return http status 400
     }
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<String> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e){
-        String message = String.format("Invalid value '%s' for parameter '%s'. Expected type: %s.",
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e){
+        String message = String.format("Invalid value type of '%s' for parameter '%s'. Expected type: %s.",
                 e.getValue(), e.getName(), e.getRequiredType().getSimpleName());
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setErrorCode(caseResourceNotFoundExceptionErrorCode);
+        errorResponse.setStatus(httpBadRequestStatus);
+        errorResponse.setMessage(message);
+        errorResponse.setTimestamp(LocalDate.now());
 //        System.out.println("message from GlobalExceptionHandler:"+message);
-        return ResponseEntity.badRequest().body(message);
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
     @ExceptionHandler(CaseParsingException.class)
@@ -45,6 +58,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CaseNullException.class)
     public ResponseEntity<String> handleCaseNullException(CaseNullException e){
         return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidCaseIdException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCaseIdException(InvalidCaseIdException e){
+        ErrorResponse errorResponse =new ErrorResponse();
+        errorResponse.setErrorCode(invalidCaseIdExceptionErrorCode);
+        errorResponse.setStatus(httpBadRequestStatus);
+        errorResponse.setMessage(e.getMessage());
+        errorResponse.setTimestamp(LocalDate.now());
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
     @ExceptionHandler(RuntimeException.class)


### PR DESCRIPTION
1.Added ErrorResponse class; 
2.Added InvalidCaseIdException
3. modified CaseController to throw exceptions for retrieve case endpoint; 
4. Modified GlobalExceptionHandler to handle retrieve case related exceptioins, making them return ErrorResponse in body
part of proof:
![image](https://github.com/user-attachments/assets/a7a38163-47b5-4c92-8fc5-4d88d2e55931)
![image](https://github.com/user-attachments/assets/b73d1076-dbcc-41a7-a41f-d5657bd0befd)
![image](https://github.com/user-attachments/assets/b80efb34-e26e-4ccf-b8d6-551c3e81b692)
